### PR TITLE
Maintenance 6.8

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -21,7 +21,7 @@ add_action( 'admin_init', function () {
 		), OBJECT );
 		if ( empty( $post_types ) ) {
 			printf( '<p class="description">%s</p>', esc_html__( 'No custom post types available.', 'tscptf' ) );
-            printf( '<p class="description">%s</p>', esc_html__( 'Note that registered custom post type\'s public parameter must be true, and has_archive parameter must be false, to be able to set this option.', 'tscptf' ) );
+			printf( '<p class="description">%s</p>', esc_html__( 'Note that registered custom post type\'s public parameter must be true, and has_archive parameter must be false, to be able to set this option.', 'tscptf' ) );
 		} else {
 			foreach ( $post_types as $post_type ) {
 				printf(

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -21,6 +21,7 @@ add_action( 'admin_init', function () {
 		), OBJECT );
 		if ( empty( $post_types ) ) {
 			printf( '<p class="description">%s</p>', esc_html__( 'No custom post types available.', 'tscptf' ) );
+            printf( '<p class="description">%s</p>', esc_html__( 'Note that registered custom post type\'s public parameter must be true, and has_archive parameter must be false, to be able to set this option.', 'tscptf' ) );
 		} else {
 			foreach ( $post_types as $post_type ) {
 				printf(

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -33,11 +33,12 @@ add_action( 'admin_init', function () {
 		}
 		// Description.
 		printf(
-			'<p class="description">%s &raquo; <a href="%s">%s</a></p>',
-			esc_html__( 'Go permalink page on change.', 'tscptf' ),
-			esc_url( admin_url( 'options-permalink.php' ) ),
-			esc_html__( 'Go to Permalink', 'tscptf' )
-		);
+			'<p class="description">%s</p>',
+			sprintf(
+				esc_html__( 'When you change the post type selection, save changes. Then, you must flush the URL rewrite rules. Go to the %1$sPermalinks%2$s settings page. You do not need to change any settings. Click save changes.', 'tscptf' ),
+				'<a href="' . esc_url( admin_url( 'options-permalink.php' ) ) . '">',
+				'</a>'
+			) );
 	}, 'reading', 'ts-cptf-section' );
 	register_setting( 'reading', 'ts-cptf-post-types' );
 } );

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -34,6 +34,7 @@ add_action( 'admin_init', function () {
 			printf(
 				'<p class="description">%s</p>',
 				sprintf(
+					/* translators: %1$s is a link opening tag, %2$s is the link closing tag */
 					esc_html__( 'When you change the post type selection, save changes. Then, you must flush the URL rewrite rules. Go to the %1$sPermalinks%2$s settings page. You do not need to change any settings. Click save changes.', 'tscptf' ),
 					'<a href="' . esc_url( admin_url( 'options-permalink.php' ) ) . '">',
 					'</a>'

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -30,15 +30,16 @@ add_action( 'admin_init', function () {
 					esc_html( $post_type->label )
 				);
 			}
+			// Description.
+			printf(
+				'<p class="description">%s</p>',
+				sprintf(
+					esc_html__( 'When you change the post type selection, save changes. Then, you must flush the URL rewrite rules. Go to the %1$sPermalinks%2$s settings page. You do not need to change any settings. Click save changes.', 'tscptf' ),
+					'<a href="' . esc_url( admin_url( 'options-permalink.php' ) ) . '">',
+					'</a>'
+				)
+			);
 		}
-		// Description.
-		printf(
-			'<p class="description">%s</p>',
-			sprintf(
-				esc_html__( 'When you change the post type selection, save changes. Then, you must flush the URL rewrite rules. Go to the %1$sPermalinks%2$s settings page. You do not need to change any settings. Click save changes.', 'tscptf' ),
-				'<a href="' . esc_url( admin_url( 'options-permalink.php' ) ) . '">',
-				'</a>'
-			) );
 	}, 'reading', 'ts-cptf-section' );
 	register_setting( 'reading', 'ts-cptf-post-types' );
 } );


### PR DESCRIPTION
- 開始タグと終了タグを使って、翻訳を一つの文字列にまとめました。
- Custom post typeがない場合は、説明を非表示にしました。その方が分かりやすいと思います。

<img width="1710" alt="taro-cpt-front" src="https://github.com/user-attachments/assets/a2fc57c9-6af7-46b9-b7db-568835bca33b" />