### PR TITLE
Standardize PHP version to >=7.4 with platform pinning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		}
 	],
 	"require": {
-		"php": ">=7.0"
+		"php": ">=7.4"
 	},
 	"require-dev": {
 		"phpunit/phpunit": ">=6",
@@ -26,6 +26,9 @@
 	"config": {
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
+		},
+		"platform": {
+			"php": "7.4"
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- composer.json: require.php を >=7.4 に統一
- composer.json: config.platform.php を 7.4 に設定（composer.lock なし運用のため）
- README.md / プラグインヘッダーの Requires PHP を 7.4 に更新
- CI ワークフローの PHP マトリクスを更新

タロスカイ全プラグイン標準化の一環。

🤖 Generated with [Claude Code](https://claude.com/claude-code)