### PR TITLE
Add PHPStan Level 5 static analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
 	"scripts": {
 		"test": "phpunit",
 		"lint": "phpcs --standard=phpcs.ruleset.xml $(find ./ -name '*.php')",
-		"fix": "phpcbf --standard=phpcs.ruleset.xml $(find ./ -name '*.php')"
+		"fix": "phpcbf --standard=phpcs.ruleset.xml $(find ./ -name '*.php')",
+		"phpstan": "phpstan analyse --memory-limit=1G"
 	},
 	"authors": [
 		{
@@ -21,7 +22,10 @@
 		"phpunit/phpunit": ">=6",
 		"squizlabs/php_codesniffer": "^3.0",
 		"wp-coding-standards/wpcs": "^3.0",
-		"yoast/phpunit-polyfills": "^1.0"
+		"yoast/phpunit-polyfills": "^1.0",
+		"phpstan/phpstan": "^2.1",
+		"szepeviktor/phpstan-wordpress": "^2.0",
+		"php-stubs/wordpress-stubs": "^6.9"
 	},
 	"config": {
 		"allow-plugins": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,25 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Parameter \#1 \$text of function esc_attr expects string, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/editor.php
+
+		-
+			message: '#^Function ts_cptf_post_type_struct\(\) should return string but returns array\.$#'
+			identifier: return.type
+			count: 1
+			path: includes/functions.php
+
+		-
+			message: '#^Found usage of constant DOING_AJAX\. Use wp_doing_ajax\(\) instead\.$#'
+			identifier: phpstanWP.wpConstant.fetch
+			count: 1
+			path: includes/settings.php
+
+		-
+			message: '#^Parameter \#2 \$output of function get_post_types expects ''names''\|''objects'', ''OBJECT'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: includes/settings.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,9 @@
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - phpstan-baseline.neon
+
+parameters:
+    level: 5
+    paths:
+        - taro-cpt-front.php
+        - includes/


### PR DESCRIPTION
## Summary
- PHPStan Level 5 + WordPress extensions を追加
- 既存エラーは baseline に記録（新規コードのみ Level 5 準拠を要求）
- `composer phpstan` で実行可能

タロスカイ全プラグイン標準化の一環。

🤖 Generated with [Claude Code](https://claude.com/claude-code)