### PR TITLE
Add phpstan files to .distignore

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -13,6 +13,8 @@ node_modules
 composer.lock
 package-lock.json
 phpcs.ruleset.xml
+phpstan-baseline.neon
+phpstan.neon
 phpunit.xml.dist
 README.md
 webpack.config.js


### PR DESCRIPTION
## Summary
- Add phpstan.neon and phpstan-baseline.neon to .distignore to exclude from WordPress.org deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)